### PR TITLE
Return the response object when there was an error

### DIFF
--- a/lib/creditguard.js
+++ b/lib/creditguard.js
@@ -101,10 +101,10 @@ module.exports = function creditguard(env, options) {
 
     const json = await xmlToJSON(xmlBody);
 
-    const { response: { result, doDeal, userMessage, tranId } } = json;
+    const { response, response: { result, doDeal, userMessage, tranId } } = json;
 
     if (result !== '000') {
-      throw new Error(userMessage);
+      throw { toString: () => userMessage, ...response };
     }
 
     if (cleanup) {


### PR DESCRIPTION
Whenever there was an error on the server-side we want to understand what was the reason. Instead of returning just `userMessage` I propose to throw the whole response object. I added the `toString` method to support backward compatibility as someone might have already used `err.toString()` inside a catch block.
Here is ![uploaded](https://api.monosnap.com/file/download?id=jX7VDsHlYpK9liIHmRk7yZDlGW1Sk6) an image which shows what is being returned now form the server and it seems like the userMessage isn't the most descriptive field there.